### PR TITLE
Fixed EF/RREF and added interactive test

### DIFF
--- a/src/AbstractSyntaxTree/Matrix.java
+++ b/src/AbstractSyntaxTree/Matrix.java
@@ -1,7 +1,6 @@
 package AbstractSyntaxTree;
 
 import java.util.*;
-import static java.util.Collections.copy;
 
 public class Matrix implements Value {
     List<Scalar> values;
@@ -14,8 +13,10 @@ public class Matrix implements Value {
         this.col_size = col_size;
     }
     public Matrix(Matrix other) {
-        this.values = new ArrayList<Scalar>();
-        copy(this.values, other.values);
+        this.values = new ArrayList<Scalar>(other.col_size * other.row_size);
+        for (int i = 0; i < other.row_size * other.col_size; i++) {
+            this.values.add(other.values.get(i));
+        }
         this.row_size = other.row_size;
         this.col_size = other.col_size;
     }

--- a/src/AbstractSyntaxTree/Matrix.java
+++ b/src/AbstractSyntaxTree/Matrix.java
@@ -40,6 +40,24 @@ public class Matrix implements Value {
         return false;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[ ");
+        for (int row = 0; row < col_size; row++) {
+            for (int col = 0; col < row_size; col++) {
+                sb.append(get(row, col).toString());
+                sb.append(' ');
+            }
+            if (row + 1 < col_size) {
+                sb.append("|\n  ");
+            } else {
+                sb.append("]");
+            }
+        }
+        return sb.toString();
+    }
+
     public int rowSize() { return row_size; }
     public int colSize() { return col_size; }
 

--- a/src/AbstractSyntaxTree/Scalar.java
+++ b/src/AbstractSyntaxTree/Scalar.java
@@ -63,6 +63,11 @@ public class Scalar implements Value{
         return (other * frac.getDenominator()) == frac.getNumerator();
     }
 
+    @Override
+    public String toString() {
+        return String.format("%d/%d", frac.getNumerator(), frac.getDenominator());
+    }
+
     public Matrix multiply(Matrix other) {
         Matrix ret = new Matrix(other);
         for (int i = 0; i < ret.col_size*ret.row_size; i++) {

--- a/src/Core/Algorithms.java
+++ b/src/Core/Algorithms.java
@@ -14,9 +14,23 @@ public class Algorithms {
         final int colSize = in.nextInt();
         final int rowSize = in.nextInt();
         in.nextLine();
+        System.out.print("Generate a random matrix? (Y/n): ");
+        final String randomChoice = in.nextLine();
+        final boolean useRandomMatrix = !(randomChoice.equalsIgnoreCase("n"));
         List<Scalar> values = new ArrayList<>();
-        for (int i = 0; i < colSize * rowSize; i++) {
-            values.add(new Scalar((int)(Math.random() * 10)));
+        if (useRandomMatrix) {
+            for (int i = 0; i < colSize * rowSize; i++) {
+                values.add(new Scalar((int)(Math.random() * 10)));
+            }
+        } else {
+            for (int row = 0; row < colSize; row++) {
+                for (int col = 0; col < rowSize; col++) {
+                    System.out.printf("A[%d, %d]: ", row, col);
+                    final int valueChoice = in.nextInt();
+                    in.nextLine();
+                    values.add(new Scalar(valueChoice));
+                }
+            }
         }
         Matrix m = new Matrix(values, rowSize, colSize);
         System.out.println("Random matrix:");

--- a/src/Core/Algorithms.java
+++ b/src/Core/Algorithms.java
@@ -3,11 +3,33 @@ package Core;
 import AbstractSyntaxTree.Matrix;
 import AbstractSyntaxTree.Scalar;
 
-import java.util.Arrays;
+import java.util.*;
 
 public class Algorithms {
 
+    public static void main(String[] args) {
+        System.out.println("Matrix EF/RREF Test");
+        Scanner in = new Scanner(System.in);
+        System.out.print("Enter matrix dimensions: ");
+        final int colSize = in.nextInt();
+        final int rowSize = in.nextInt();
+        in.nextLine();
+        List<Scalar> values = new ArrayList<>();
+        for (int i = 0; i < colSize * rowSize; i++) {
+            values.add(new Scalar((int)(Math.random() * 10)));
+        }
+        Matrix m = new Matrix(values, rowSize, colSize);
+        System.out.println("Random matrix:");
+        System.out.println(m);
+        System.out.println("Echelon form:");
+        System.out.println(ef(m));
+        System.out.println("Row-reduced echelon form:");
+        System.out.println(rref(m));
+    }
+
     public static Matrix rowSwap(Matrix m, int r1, int r2) {
+        assert(r1 >= 0 && r1 < m.colSize());
+        assert(r2 >= 0 && r2 < m.colSize());
         Matrix ret = new Matrix(m);
         for (int col = 0; col < m.rowSize(); col++) {
             ret.set(r1, col, m.get(r2, col));
@@ -17,6 +39,8 @@ public class Algorithms {
     }
 
     public static Matrix rowScale(Matrix m, int row, Scalar scale) {
+        assert(row >= 0 && row < m.colSize());
+        assert(!scale.equals(0));
         Matrix ret = new Matrix(m);
         for (int col = 0; col < m.rowSize(); col++) {
             ret.set(row, col, scale.multiply(m.get(row, col)));
@@ -25,6 +49,8 @@ public class Algorithms {
     }
 
     public static Matrix rowReplace(Matrix m, int rowTarget, int rowSource, Scalar scale) {
+        assert(rowTarget >= 0 && rowTarget < m.colSize());
+        assert(rowSource >= 0 && rowSource < m.colSize());
         Matrix ret = new Matrix(m);
         for (int col = 0; col < m.rowSize(); col++) {
             ret.set(rowTarget, col, m.get(rowTarget, col).add(scale.multiply(m.get(rowSource, col))));
@@ -34,35 +60,49 @@ public class Algorithms {
 
     public static Matrix ef(Matrix m) {
         Matrix ret = new Matrix(m);
-        // sort rows in increasing order of leading zero count
-        int[] leadingZeroesInRow = new int[m.colSize()];
-        Arrays.fill(leadingZeroesInRow, 0);
-        for (int row = 0; row < m.colSize(); row++) {
-            for (int col = 0; ret.get(row, col).equals(0); col++) {
-                leadingZeroesInRow[row]++;
-            }
-            // move row into sorted position, also swapping precomputed zero counts
-            for (int swapRow = row; swapRow > 0; swapRow--) {
-                if (leadingZeroesInRow[swapRow] < leadingZeroesInRow[swapRow - 1]) {
-                    ret = rowSwap(ret, swapRow, swapRow - 1);
-                    int tmp = leadingZeroesInRow[swapRow];
-                    leadingZeroesInRow[swapRow] = leadingZeroesInRow[swapRow - 1];
-                    leadingZeroesInRow[swapRow - 1] = tmp;
-                } else {
+        do {
+            // check if all rows have unique pivot columns
+            Map<Integer, Integer> pivotRowMap = new HashMap<>();
+            Integer rowReplaceTarget = null, rowReplaceSource = null, rowReplaceColumn = null;
+            for (int row = 0; row < m.colSize(); row++) {
+                int pivotPos = pivotPos(ret, row);
+                if (pivotPos == m.rowSize()) {
+                    continue; // ignore all-zero rows
+                }
+                if (pivotRowMap.containsKey(pivotPos)) {
+                    rowReplaceTarget = row;
+                    rowReplaceSource = pivotRowMap.get(pivotPos);
+                    rowReplaceColumn = pivotPos;
                     break;
+                } else {
+                    pivotRowMap.put(pivotPos, row);
                 }
             }
-        }
-        // ensure no two rows have the same number of leading zeroes
-        for (int row = 1; row < m.colSize(); row++) {
-            if (leadingZeroesInRow[row] == leadingZeroesInRow[row - 1]) {
-                int pivotCol = leadingZeroesInRow[row];
-                Scalar scalar = ret.get(row, pivotCol).divide(ret.get(row - 1, pivotCol)).negate();
-                ret = rowReplace(ret, row, row - 1, scalar);
-                leadingZeroesInRow[row]++;
+            // two rows had a matching pivot column; perform a row replacement
+            if (rowReplaceColumn != null) {
+                Scalar scale = ret.get(rowReplaceSource, rowReplaceColumn)
+                        .divide(ret.get(rowReplaceTarget, rowReplaceColumn))
+                        .negate();
+                ret = rowReplace(ret, rowReplaceTarget, rowReplaceSource, scale);
+            } else {
+                // do the sorting; todo do better than n^2
+                int[] pivotColAtRow = new int[m.colSize()];
+                for (int row = 0; row < m.colSize(); row++) {
+                    pivotColAtRow[row] = pivotPos(ret, row);
+                }
+                for (int row = 0; row < m.colSize(); row++) {
+                    for (int swapRow = row + 1; swapRow < m.colSize(); swapRow++) {
+                        if (pivotColAtRow[swapRow - 1] > pivotColAtRow[swapRow]) {
+                            ret = rowSwap(ret, swapRow - 1, swapRow);
+                            int temp = pivotColAtRow[swapRow - 1];
+                            pivotColAtRow[swapRow - 1] = pivotColAtRow[swapRow];
+                            pivotColAtRow[swapRow] = temp;
+                        }
+                    }
+                }
+                return ret;
             }
-        }
-        return ret;
+        } while (true);
     }
 
     public static Matrix rref(Matrix m) {
@@ -71,7 +111,7 @@ public class Algorithms {
         for (int row = 0; row < m.colSize(); row++) {
             // find the pivot column
             int pivotCol = 0;
-            while (ret.get(row, pivotCol).equals(0) && pivotCol < m.rowSize()) {
+            while (pivotCol < m.rowSize() && ret.get(row, pivotCol).equals(0)) {
                 pivotCol++;
             }
             if (pivotCol == m.rowSize()) {
@@ -87,5 +127,18 @@ public class Algorithms {
             }
         }
         return ret;
+    }
+
+    private static int pivotPos(Matrix m, int row) {
+        assert(row >= 0 && row < m.colSize());
+        int zeroCount = 0;
+        for (int col = 0; col < m.rowSize(); col++) {
+            if (m.get(row, col).equals(0)) {
+                zeroCount++;
+            } else {
+                break;
+            }
+        }
+        return zeroCount;
     }
 }


### PR DESCRIPTION
Added a simple interactive test in which a user can specify a matrix size and a random matrix will be printed along with its echelon and row-reduced forms.

Also fixed a bug in which the `java.util.Collections.copy` call in the Matrix copy constructor failed due to the destination collection being the wrong size.

Known bug: running EF/RREF on matrices around 8x8 in size will throw an `org.apache.commons.math3.exception.MathArithmeticException` with the unhelpful message "arithmetic exception". It may be some kind of overflow; in that case, `BigFraction` may be needed.