### PR TITLE
Matrix row-augmenting and row- and column-partitioning

### DIFF
--- a/src/Core/Algorithms.java
+++ b/src/Core/Algorithms.java
@@ -243,7 +243,7 @@ public class Algorithms {
             throw new IllegalArgumentException("Vector must have same dimension as space that may span it.");
         }
         Matrix mat = new Matrix(vs);
-        mat = mat.augment(u);
+        mat = mat.augmentColumns(u);
         final Matrix efMat = ef(mat).getFirst();
         return isConsistent(efMat);
     }


### PR DESCRIPTION
* Matrices can be augmented column-wise (original) or row-wise
* Matrices can be partitioned by a row or column index
    * an index of 0 or `col_size` (for row partitioning) or `row_size` (for column partitioning) returns a null matrix and a copy of the original matrix