### PR TITLE
Fixed issues casting `Matrix` to `Vector`

### DIFF
--- a/src/AbstractSyntaxTree/Vector.java
+++ b/src/AbstractSyntaxTree/Vector.java
@@ -35,7 +35,7 @@ public final class Vector extends Matrix implements Value {
 
     @Override
     public Vector multiply(Scalar s) {
-        return (Vector)super.multiply(s);
+        return super.multiply(s).asVector();
     }
 
     public Scalar dot(Vector other) {

--- a/src/Interpreter/LinearInterpreter.java
+++ b/src/Interpreter/LinearInterpreter.java
@@ -67,6 +67,10 @@ public class LinearInterpreter {
                     case MUL -> l.multiply(r);
                     case DIV -> l.divide(r);
                 };
+                case Vector r -> switch (binaryOperation.getOp()) {
+                    case MUL -> r.multiply(l);
+                    default -> throw new IllegalStateException("Unexpected value: " + binaryOperation.getOp());
+                };
                 case Matrix r -> switch (binaryOperation.getOp()) {
                     case MUL -> l.multiply(r);
                     default -> throw new IllegalStateException("Unexpected value: " + binaryOperation.getOp());


### PR DESCRIPTION
Vector-Scalar multiplication now properly casts Matrix to Vector